### PR TITLE
feat : Add putmapping and deletemapping in BoardController

### DIFF
--- a/src/main/java/com/espinas/fhir/rest/controller/api/board/BoardController.java
+++ b/src/main/java/com/espinas/fhir/rest/controller/api/board/BoardController.java
@@ -3,10 +3,13 @@ package com.espinas.fhir.rest.controller.api.board;
 import com.espinas.fhir.rest.dto.request.board.BoardRequest;
 import com.espinas.fhir.rest.dto.response.board.BoardResponse;
 import org.springframework.web.bind.annotation.*;
+
 import javax.validation.Valid;
+
 @RestController
+@RequestMapping("/board")
 public class BoardController {
-    @GetMapping("/board")
+    @GetMapping("/get")
     public BoardResponse boardResponse() {
         return BoardResponse.builder()
                 .boardId(1L)
@@ -15,8 +18,24 @@ public class BoardController {
                 .writer("jj")
                 .build();
     }
-    @PostMapping("/board")
+
+    @PostMapping("/post")
     public BoardRequest boardRequest(@Valid @RequestBody BoardRequest boardRequest) {
         return boardRequest;
     }
- }
+
+    @PutMapping("/put")
+    public BoardRequest brq(@Valid @RequestBody BoardRequest brq) {
+        return brq;
+    }
+
+    @DeleteMapping("/delete")
+    public BoardRequest boardRequest() {
+        return BoardRequest.builder()
+                .boardId(2L)
+                .title("2222")
+                .contents("aaa")
+                .writer("ee")
+                .build();
+    }
+}

--- a/src/main/java/com/espinas/fhir/rest/controller/api/board/BoardController.java
+++ b/src/main/java/com/espinas/fhir/rest/controller/api/board/BoardController.java
@@ -7,9 +7,10 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
 @RestController
+@RequestMapping("/board")
 public class BoardController {
-    @GetMapping("/board")
-    public BoardResponse roadboard() {
+    @GetMapping
+    public BoardResponse loadBoard() {
         return BoardResponse.builder()
                 .boardId(1L)
                 .title("title")
@@ -18,18 +19,18 @@ public class BoardController {
                 .build();
     }
 
-    @PostMapping("/board")
-    public BoardRequest createboard(@Valid @RequestBody BoardRequest boardRequest) {
+    @PostMapping
+    public BoardRequest createBoard(@Valid @RequestBody BoardRequest boardRequest) {
         return boardRequest;
     }
 
-    @PutMapping("/board")
-    public BoardRequest putboard(@Valid @RequestBody BoardRequest boardRequest) {
+    @PutMapping
+    public BoardRequest putBoard(@Valid @RequestBody BoardRequest boardRequest) {
         return boardRequest;
     }
 
-    @DeleteMapping("/board/{boardId}")
-    public BoardRequest deleteboard(@PathVariable Long boardId) {
+    @DeleteMapping("/{boardId}")
+    public BoardRequest deleteBoard(@PathVariable Long boardId) {
         return BoardRequest.builder()
                 .boardId(boardId)
                 .build();

--- a/src/main/java/com/espinas/fhir/rest/controller/api/board/BoardController.java
+++ b/src/main/java/com/espinas/fhir/rest/controller/api/board/BoardController.java
@@ -10,7 +10,7 @@ import javax.validation.Valid;
 @RequestMapping("/board")
 public class BoardController {
     @GetMapping
-    public BoardResponse loadBoard() {
+    public BoardResponse getBoard() {
         return BoardResponse.builder()
                 .boardId(1L)
                 .title("title")
@@ -20,12 +20,12 @@ public class BoardController {
     }
 
     @PostMapping
-    public BoardRequest createBoard(@Valid @RequestBody BoardRequest boardRequest) {
+    public BoardRequest addBoard(@Valid @RequestBody BoardRequest boardRequest) {
         return boardRequest;
     }
 
     @PutMapping
-    public BoardRequest putBoard(@Valid @RequestBody BoardRequest boardRequest) {
+    public BoardRequest updateBoard(@Valid @RequestBody BoardRequest boardRequest) {
         return boardRequest;
     }
 

--- a/src/main/java/com/espinas/fhir/rest/controller/api/board/BoardController.java
+++ b/src/main/java/com/espinas/fhir/rest/controller/api/board/BoardController.java
@@ -7,10 +7,9 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
 @RestController
-@RequestMapping("/board")
 public class BoardController {
-    @GetMapping("/get")
-    public BoardResponse boardResponse() {
+    @GetMapping("/board")
+    public BoardResponse roadboard() {
         return BoardResponse.builder()
                 .boardId(1L)
                 .title("title")
@@ -19,23 +18,20 @@ public class BoardController {
                 .build();
     }
 
-    @PostMapping("/post")
-    public BoardRequest boardRequest(@Valid @RequestBody BoardRequest boardRequest) {
+    @PostMapping("/board")
+    public BoardRequest createboard(@Valid @RequestBody BoardRequest boardRequest) {
         return boardRequest;
     }
 
-    @PutMapping("/put")
-    public BoardRequest brq(@Valid @RequestBody BoardRequest brq) {
-        return brq;
+    @PutMapping("/board")
+    public BoardRequest putboard(@Valid @RequestBody BoardRequest boardRequest) {
+        return boardRequest;
     }
 
-    @DeleteMapping("/delete")
-    public BoardRequest boardRequest() {
+    @DeleteMapping("/board/{boardId}")
+    public BoardRequest deleteboard(@PathVariable Long boardId) {
         return BoardRequest.builder()
-                .boardId(2L)
-                .title("2222")
-                .contents("aaa")
-                .writer("ee")
+                .boardId(boardId)
                 .build();
     }
 }

--- a/src/main/java/com/espinas/fhir/rest/dto/request/board/BoardRequest.java
+++ b/src/main/java/com/espinas/fhir/rest/dto/request/board/BoardRequest.java
@@ -14,12 +14,10 @@ public class BoardRequest {
     @NotNull
     private Long boardId;
     @NotBlank
-    @NotEmpty
     private String title;
-    @NotNull
     @NotEmpty
     private String contents;
-    @NotNull
+    @NotBlank
     private String writer;
 
     @Builder

--- a/src/main/java/com/espinas/fhir/rest/dto/request/board/BoardRequest.java
+++ b/src/main/java/com/espinas/fhir/rest/dto/request/board/BoardRequest.java
@@ -3,6 +3,9 @@ package com.espinas.fhir.rest.dto.request.board;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 @Getter
@@ -10,12 +13,15 @@ import javax.validation.constraints.NotNull;
 public class BoardRequest {
     @NotNull
     private Long boardId;
-    @NotNull
+    @NotBlank
+    @NotEmpty
     private String title;
     @NotNull
+    @NotEmpty
     private String contents;
     @NotNull
     private String writer;
+
     @Builder
     public BoardRequest(Long boardId, String title, String contents, String writer) {
         this.boardId = boardId;


### PR DESCRIPTION
BoardController에 putmapping과 deletemapping 구현 했습니다.
Putmapping도 postmapping 처럼 유효성 검증이 필요한 것 같아 valid 어노테이션 이용하였습니다.
url도 class 단위로 baord라고 묶어주고 기능 메소드 별로 get/post/put/delete로 나눠봤습니다.
확인 부탁드립니다.